### PR TITLE
Set up COMPOSER_ROOT_VERSION for Pull Requests

### DIFF
--- a/hack-lint-test/action.yml
+++ b/hack-lint-test/action.yml
@@ -31,6 +31,8 @@ runs:
         hh_client --version
     - name: Install project dependencies
       shell: bash
+      env:
+        COMPOSER_ROOT_VERSION: dev-${{github.base_ref || github.ref_name}}
       run: |
         echo "::group::Install project dependencies"
         FLAGS=""


### PR DESCRIPTION
Suppose a developer submitted some commits into a branch called `my-branch`, and created a Pull Request to merge `my-branch` onto `main`. The composer tool will consider the current version as `dev-my-branch`. Unfortunately we created `branch-alias` for `dev-main`, not `dev-my-branch`. As a result, `composer` cannot determine the version of current root project.

This PR instead passes the `github.base_ref` to `$COMPOSER_ROOT_VERSION`, which is `dev-main`, allowing `composer` to determine the version with the help of `branch-alias`.

- See https://github.com/hhvm/hh-clilib/pull/34 for how this approach works
- See https://github.com/laminas/laminas-cache-storage-adapter-memory/blob/f47aed9d5f6f3eac5970693ea5898d67d3f33dcf/.laminas-ci/composer-root-version.sh for examples how other people calculate `$COMPOSER_ROOT_VERSION`