### PR TITLE
Invoke Hack binaries directly

### DIFF
--- a/hack-lint-test/lint.sh
+++ b/hack-lint-test/lint.sh
@@ -30,6 +30,6 @@ fi
 echo "::group::Lint"
 (
   set -x
-  hhvm $FLAGS vendor/bin/hhast-lint
+  hhvm $FLAGS vendor/hhvm/hhast/bin/hhast-lint
 )
 echo "::endgroup::"

--- a/hack-lint-test/test.sh
+++ b/hack-lint-test/test.sh
@@ -24,6 +24,6 @@ fi
 echo "::group::Run tests"
 (
   set -x
-  hhvm $FLAGS vendor/bin/hacktest tests/
+  hhvm $FLAGS vendor/hhvm/hacktest/bin/hacktest tests/
 )
 echo "::endgroup::"


### PR DESCRIPTION
Composer creates wrapping shell scripts instead of symlinks.
We can not invoke a shell script with hhvm.
Calling the binaries directly is dirty, but the only way.
If we invoke the shell script, we can not add hhvm $FLAGS.