### PR TITLE
Don't set COMPOSER_ROOT_VERSION when running CI for a tag

### DIFF
--- a/hack-lint-test/action.yml
+++ b/hack-lint-test/action.yml
@@ -29,10 +29,10 @@ runs:
       run: |
         hhvm --version
         hh_client --version
+    - if: github.ref_type != 'tag'
+      run: echo "COMPOSER_ROOT_VERSION=dev-${{github.base_ref || github.ref_name}}" >> $GITHUB_ENV
     - name: Install project dependencies
       shell: bash
-      env:
-        COMPOSER_ROOT_VERSION: dev-${{github.base_ref || github.ref_name}}
       run: |
         echo "::group::Install project dependencies"
         FLAGS=""

--- a/hack-lint-test/action.yml
+++ b/hack-lint-test/action.yml
@@ -30,6 +30,7 @@ runs:
         hhvm --version
         hh_client --version
     - if: github.ref_type != 'tag'
+      shell: bash
       run: echo "COMPOSER_ROOT_VERSION=dev-${{github.base_ref || github.ref_name}}" >> $GITHUB_ENV
     - name: Install project dependencies
       shell: bash


### PR DESCRIPTION
Previously `COMPOSER_ROOT_VERSION` was like `dev-v2.4.0` when CI is triggered by a tag, and resulted in errors as following
https://github.com/hhvm/hacktest/runs/6761433581?check_suite_focus=true

This PR fixed the error by only set `COMPOSER_ROOT_VERSION` for branches and pull requests